### PR TITLE
docs: fix imports in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The only argument contains an object with a deserialized message. All data sent 
 ###### Parent
 
 ```ts
-import Framecast from 'framecast';
+import { Framecast } from 'framecast';
 
 const target = document.querySelector('iframe').contentWindow;
 const framecast = new Framecast(target);
@@ -48,7 +48,7 @@ framecast.on('broadcast', (message: any) => {
 ###### Child
 
 ```ts
-import Framecast from 'framecast';
+import { Framecast } from 'framecast';
 
 const target = window.parent;
 const framecast = new Framecast(target);
@@ -69,7 +69,7 @@ Create a function by adding a listener for the `function:*` event where `*` is t
 ###### Child
 
 ```ts
-import Framecast from 'framecast';
+import { Framecast } from 'framecast';
 
 const target = window.parent;
 const framecast = new Framecast(target);
@@ -86,7 +86,7 @@ To call the function from another frame, we use `call`. Note, that all functions
 ###### Parent
 
 ```ts
-import Framecast from 'framecast';
+import { Framecast } from 'framecast';
 
 const target = document.querySelector('iframe').contentWindow;
 const framecast = new Framecast(target);


### PR DESCRIPTION
**Changes:**
- Fixes the import statements in `README.md` examples

Noticed `Framecast` is a named export after trying to use a default import

<img width="751" alt="Screen Shot 2022-08-15 at 11 21 00 AM" src="https://user-images.githubusercontent.com/3903325/184664296-38c61d2d-629c-4d14-8e37-f7b6a466a2f9.png">
