### PR TITLE
Add support for custom error properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type FramecastConfig = {
   self: Window | null;
   functionTimeoutMs: number;
   supportEvaluate: boolean;
+  allowErrorProps?: string[];
 };
 
 /**
@@ -82,6 +83,10 @@ export class Framecast {
       this.on('function:evaluate', async (fn: string) => {
         return eval(fn);
       });
+    }
+
+    if (this.config.allowErrorProps && this.config.allowErrorProps.length > 0) {
+      superjson.allowErrorProps(...this.config.allowErrorProps);
     }
   }
 


### PR DESCRIPTION
```js
class UserError extends Error {
  constructor(message, error) {
    super(message, { cause: error });
    this.name = 'UserError';
    this.foo = 'Is Foo';
  }
}

const framecast = new Framecast(window.parent, {
  allowErrorProps: ['foo'],
});
```