### PR TITLE
Replace `Date.now()` with `nanoid()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "framecast",
-  "version": "0.0.9",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "framecast",
-      "version": "0.0.9",
+      "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
+        "nanoid": "^5.1.2",
         "nanostores": "^0.9.5",
         "superjson": "^1.9.1"
       },
@@ -6770,6 +6771,23 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
+      "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/nanostores": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.9.5.tgz",
@@ -13305,6 +13323,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nanoid": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
+      "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g=="
     },
     "nanostores": {
       "version": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "nanoid": "^5.1.2",
     "nanostores": "^0.9.5",
     "superjson": "^1.9.1"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { atom, WritableAtom, onMount } from 'nanostores';
 import superjson from 'superjson';
+import { nanoid } from 'nanoId';
 
 export { WritableAtom } from 'nanostores';
 
@@ -62,7 +63,7 @@ export class Framecast {
    * Map of pending function calls
    */
   private pendingFunctionCalls: Map<
-    number,
+    string,
     { timeout: number; resolve: Function; reject: Function }
   > = new Map();
 
@@ -182,7 +183,7 @@ export class Framecast {
     functionName: string,
     ...args: any[]
   ): Promise<ReturnValue> {
-    const id = Date.now();
+    const id = nanoid();
 
     if (!this.config.functionTimeoutMs) {
       throw new Error(
@@ -224,7 +225,7 @@ export class Framecast {
     functionName: string,
     ...args: any[]
   ): { result: Promise<ReturnValue>; dispose: () => void } {
-    const id = Date.now();
+    const id = nanoid();
 
     const promise = new Promise<ReturnValue>((resolve, reject) => {
       this.pendingFunctionCalls.set(id, { timeout: -1, resolve, reject });
@@ -413,7 +414,7 @@ export class Framecast {
    */
   private async handleFunctionResult(data: {
     type: 'functionResult';
-    id: number;
+    id: string;
     result?: any;
     error?: Error;
   }) {
@@ -435,7 +436,7 @@ export class Framecast {
    * Clears a pending function call
    * @param id The id of the pending function call
    */
-  private clearPendingFunctionCall(id: number) {
+  private clearPendingFunctionCall(id: string) {
     const pendingCall = this.pendingFunctionCalls.get(id);
     if (pendingCall) {
       this.pendingFunctionCalls.delete(id);


### PR DESCRIPTION
Using a timestamp as an id was causing issue with duplicated ids when multiple `call` functions were being triggered at the same time. Only the latest one would get resolved.