### PR TITLE
Remove `nanoid` non-secure import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { atom, WritableAtom, onMount } from 'nanostores';
 import superjson from 'superjson';
-import { nanoid } from 'nanoId/non-secure';
+import { nanoid } from 'nanoId';
 
 export { WritableAtom } from 'nanostores';
 


### PR DESCRIPTION
We can remove the `non-secure` import and whoever is imports will need to set the correct `--platform node|browser` while compiling